### PR TITLE
Cl prefix and test

### DIFF
--- a/ndmacro-test.el
+++ b/ndmacro-test.el
@@ -1,0 +1,118 @@
+;;; ndmacro-test.el --- test for ndmacro.el           -*- lexical-binding: t; -*-
+
+;; Author: ril <fenril.nh@gmail.com>
+;; Keywords: convenience
+
+;;; Commentary:
+
+;; emacs -Q -l ndmacro.el --batch --eval '(load-file "ndmacro:test.el")'
+
+;;; Code:
+(require 'ert)
+(require 'ndmacro)
+
+(ert-deftest ndmacro:util-group-1 ()
+  (should (equal '((1 2 3) (4 5 6) (7 8 9))
+                 (ndmacro:util-group '(1 2 3 4 5 6 7 8 9) 3))))
+
+(ert-deftest ndmacro:list-shift-1 ()
+  (should (equal '((1 2) (3 4 5 6))
+                 (ndmacro:list-shift
+                  '(1 2 3) '(4 5 6)))))
+
+(ert-deftest ndmacro:seq-prefix-matched-1 ()
+  (should (equal '(2 1 0 "A")
+                 (ndmacro:seq-prefix-matched
+                  '(2 1 0 "A" 5 4 3) '(2 1 0 "A" "H" "O")))))
+
+(ert-deftest ndmacro:search-loop-0 ()   ; fail
+    (should (equal '((("a" "b" "a" "b" "c" "c") ("a" "b" "a" "b" "c" "c")) 0)
+                   (cl-multiple-value-list
+                    (ndmacro:search-loop
+                     '("a" "b" "a" "b" "c" "c"
+                       "a" "b" "a" "b" "c" "c" "d" "e" "f" "g"))))))
+
+(ert-deftest ndmacro:search-loop-1 ()   ; fail
+    (should (equal '((("a" "b") ("a" "b")) 0)
+                   (ndmacro:search-loop
+                    '("a" "b" "a" "b" "c" "-"
+                      "a" "b" "a" "b" "c" "c" "d" "e" "f" "g")))))
+
+(ert-deftest ndmacro:search-loop-2 ()
+    (should (equal '((("a" "b") ("a" "b")) 0)
+                   (ndmacro:search-loop
+                    '("a" "b"
+                      "a" "b")))))
+
+(ert-deftest ndmacro:search-loop-3 ()
+    (should (equal '((("a" "b") ("a" "b") ("a" "b")) 0)
+                   (ndmacro:search-loop
+                    '("a" "b"
+                      "a" "b" "a" "b")))))
+
+(ert-deftest ndmacro:search-loop-4 ()
+    (should (equal '((("a" "b" "a" "b") ("a" "b" "a" "b")) 0)
+                   (ndmacro:search-loop
+                     '("a" "b" "a" "b"
+                       "a" "b" "a" "b")))))
+
+(ert-deftest ndmacro:search-loop-5 ()
+  (should (equal '(((49 48 49 44) (49 48 50 44) (49 48 51 44)) 0)
+                 (ndmacro:search-loop
+                  '(49 48 49 44
+                       49 48 50 44
+                       49 48 51 44)))))
+
+(ert-deftest ndmacro:search-loop-6 ()
+  (should (equal '(((5 4 3 2 1 0 "A") (5 4 3 2 1 0 "A")) 4)
+                 (ndmacro:search-loop
+                  '(2 1 0 "A" 5 4 3 2 1 0 "A" "H" "O")))))
+
+(ert-deftest ndmacro:predict-repeat-1 () ; fail, probably inverse order
+  (should (equal ' ((("A" 0 1 2 3 4 5) ("A" 0 1 2 3 4 5)) 4)
+                   (ndmacro:predict-repeat
+                    '(2 1 0 "A" 5 4 3 2 1 0 "A" "H" "O")))))
+
+(ert-deftest ndmacro:split-seq-if-1 ()
+  (should (equal '((49 51) (49 52))
+                 (ndmacro:split-seq-if
+                  'identity '(49 51 nil 49 52 nil)))))
+
+(ert-deftest ndmacro:split-seq-if-2 ()
+  (should (equal '((49 51) (49 52))
+                 (ndmacro:split-seq-if
+                  'identity '(nil 49 51 nil 49 52 nil)))))
+
+(ert-deftest ndmacro:split-seq-if-3 ()
+  (should (equal '((49 51) (49 52))
+                 (ndmacro:split-seq-if
+                  'identity '(nil 49 51 nil 49 52)))))
+
+(ert-deftest ndmacro:position-subseq-1 ()
+  (should (= 1
+             (ndmacro:position-subseq
+              '(nil 49 51 nil 49 52) '(49 51)))))
+
+(ert-deftest ndmacro:position-subseq-2 ()
+  (should (= 4
+             (ndmacro:position-subseq
+              '(nil 49 51 nil 49 52) '(49 52)))))
+
+(ert-deftest ndmacro:get-numbers-and-position-1 ()
+  "1の位置から３桁分105, 5の位置から2桁分13がある。"
+  (should (equal '((1 3 103) (5 2 13))
+                 (ndmacro:get-numbers-and-position
+                  '(nil 49 48 51 nil 49 51 nil nil)))))
+
+(ert-deftest ndmacro:get-incremented-sequence-1 () ; fail
+    (equal '(49 48 53 44 49 55 65 return) ;"105,17A"
+           (ndmacro:get-incremented-sequence
+            '((return 65 53 49 44 52 48 49) ;"104,15A"
+              (return 65 51 49 44 51 48 49) ;"103,13A"
+              (return 65 49 49 44 50 48 49) ;"102,11A"
+              ))))
+
+(ert-run-tests-batch-and-exit)
+
+(provide 'ndmacro:test)
+;;; ndmacro-test.el ends here

--- a/ndmacro-test.el
+++ b/ndmacro-test.el
@@ -105,12 +105,12 @@
                   '(nil 49 48 51 nil 49 51 nil nil)))))
 
 (ert-deftest ndmacro:get-incremented-sequence-1 () ; fail
-    (equal '(49 48 53 44 49 55 65 return) ;"105,17A"
-           (ndmacro:get-incremented-sequence
-            '((return 65 53 49 44 52 48 49) ;"104,15A"
-              (return 65 51 49 44 51 48 49) ;"103,13A"
-              (return 65 49 49 44 50 48 49) ;"102,11A"
-              ))))
+  (should (equal '(49 48 53 44 49 55 65 return)           ;"105,17A"
+                 (ndmacro:get-incremented-sequence
+                  '((return 65 53 49 44 52 48 49)  ;"104,15A"
+                    (return 65 51 49 44 51 48 49)  ;"103,13A"
+                    (return 65 49 49 44 50 48 49)  ;"102,11A"
+                    )))))
 
 (ert-run-tests-batch-and-exit)
 

--- a/ndmacro.el
+++ b/ndmacro.el
@@ -202,15 +202,15 @@
           (cl-mapcar 'list ; 位置情報もくっつけとく。
                    lst1
                    (cl-mapcar '+ ; 足すと次の数字になって↑↑
-                            (mapcar 'third lst1)
+                            (mapcar 'cl-third lst1)
                             (mapcar (lambda (e) (* *ndmacro-repeat-count* e)); 連続実行の場合は実行回数をかけて↑↑
                                     (cl-mapcar '- ; 差を出して↑↑
-                                             (mapcar 'third lst1)
-                                             (mapcar 'third lst2)))
+                                             (mapcar 'cl-third lst1)
+                                             (mapcar 'cl-third lst2)))
                             )))
-         (result-seq (copy-list (car lst))))
+         (result-seq (cl-copy-list (car lst))))
     (dolist (l next-number) ;;繰り返し1つの中に複数数字がある場合に備えて
-      (let ((chars (map 'list 'identity (substring (format "000000000000000000%d" (max 0 (cadr l))) ;;桁数維持
+      (let ((chars (cl-map 'list 'identity (substring (format "000000000000000000%d" (max 0 (cadr l))) ;;桁数維持
                                                    (- (cadar l))
                                                    ))))
         (dotimes (n (cadar l))


### PR DESCRIPTION
- fix illegal use of `nth` in `ndmacro:seq-prefix-matched`
-  use `cl-lib.el` instead of `cl.el`
- add test script from comments in code, but some tests fails
   
The tests failed are below.  I think the expectations in comments may be wrong.

 ``` emacs-lisp
(ndmacro:predict-repeat
  '(2 1 0 "A" 5 4 3 2 1 0 "A" "H" "O"))
;; => ((("A" 0 1 2 3 4 5) ("A" 0 1 2 3 4 5)) 4)

(multiple-value-list (ndmacro:search-loop
   '("a" "b" "a" "b" "c" "c"
     "a" "b" "a" "b" "c" "c" "d" "e" "f" "g")))
;; => ((("a" "b" "a" "b" "c" "c") ("a" "b" "a" "b" "c" "c")) 0)

(ndmacro:search-loop
   '("a" "b" "a" "b" "c" "-"
     "a" "b" "a" "b" "c" "c" "d" "e" "f" "g"))
;; => ((("a" "b") ("a" "b")) 0)

(ndmacro:get-incremented-sequence
'((return 65 53 49 44 52 48 49);"104,15A"
  (return 65 51 49 44 51 48 49);"103,13A"
  (return 65 49 49 44 50 48 49);"102,11A"
  ))
;; => (49 48 53 44 49 55 65 return);"105,17A"
```